### PR TITLE
empty classes setting

### DIFF
--- a/DependencyInjection/SymfonyCmfBlogExtension.php
+++ b/DependencyInjection/SymfonyCmfBlogExtension.php
@@ -35,7 +35,7 @@ class SymfonyCmfBlogExtension extends Extension
             'post_admin' => 'Symfony\Cmf\Bundle\BlogBundle\Admin\PostAdmin',
             'blog' => 'Symfony\Cmf\Bundle\BlogBundle\Document\Blog',
             'post' => 'Symfony\Cmf\Bundle\BlogBundle\Document\Post',
-        ), isset($config['class']) ? $config['class']: array());
+        ), isset($config['class']) ? $config['class'] : array());
 
         foreach ($config['class'] as $type => $classFqn) {
             $container->setParameter(


### PR DESCRIPTION
If the following setting is not present the user if congratulated with an error:

```
symfony_cmf_blog
    class: ~
```

The error is:

```
>php app\console cache:clear

  [ErrorException]
  Notice: Undefined index: class in ...\vendor\symfony-cmf\blog-bundle\Symfony\Cmf\Bundle\BlogBundle\DependencyInjection\SymfonyCmfBlogExtension.php line 38
```

The commit handles the case where the 'class' index may not exist.
