### PR TITLE
add rdf mapping for blog posts

### DIFF
--- a/Resources/rdf-mappings/Symfony.Cmf.Bundle.BlogBundle.Document.Post.xml
+++ b/Resources/rdf-mappings/Symfony.Cmf.Bundle.BlogBundle.Document.Post.xml
@@ -1,0 +1,9 @@
+<type
+        xmlns:schema="http://schema.org/"
+        typeof="schema:WebPage"
+        >
+    <children>
+        <property property="schema:headline" identifier="title" tag-name="h1"/>
+        <property property="schema:text" identifier="body" />
+    </children>
+</type>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

this is a simple mapping for the blog post.

we could also change the template, but that would create a dependency on CreateBundle. this bundle probably should not provide a template anyways - the other bundles don't.

```
+{% createphp post as="rdf" %}
+
 <div class="row-fluid">
     <div class="span12">
-        <h1>{{ post.title }}</h1>
+        {{ rdf.title|raw }}
     </div>
 </div>
 <div class="row-fluid">
@@ -25,9 +28,11 @@
     </div>
 </div>
 <div class="row-fluid">
-    <div class="span12">
-        {{ post.body|nl2br|raw }}
+    <div class="span12" {{ createphp_attributes(rdf.body) }}>
+        {{ createphp_content(rdf.body)|nl2br|raw }}
     </div>
 </div>
+{% endcreatephp %}
```
